### PR TITLE
change native name macros for wals

### DIFF
--- a/langnames/ln_langs_wals_native.tex
+++ b/langnames/ln_langs_wals_native.tex
@@ -1,3 +1,3 @@
-\def\langnames@langs@native@glottolog@deu{Deutsch}
-\def\langnames@langs@native@glottolog@jpn{日本語}
-\def\langnames@langs@native@glottolog@mar{मराठी}
+\def\langnames@langs@native@wals@deu{Deutsch}
+\def\langnames@langs@native@wals@jpn{日本語}
+\def\langnames@langs@native@wals@mar{मराठी}


### PR DESCRIPTION
macros were set to glottolog, meaning they didn't work when wals was selected as the database.